### PR TITLE
Fix allowed payment methods

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven' // Required for publishing to packagecloud
 
 group "au.com.woolworths.village.sdk.openapi"
-version "4.0.0"
+version "4.0.1"
 
 android {
     compileSdkVersion 29

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation "androidx.core:core-ktx:1.3.0"
     implementation "androidx.appcompat:appcompat:1.1.0"
 
-    implementation "au.com.woolworths.village.sdk:sdk:4.0.0"
+    implementation "au.com.woolworths.village.sdk:sdk:4.0.1"
     implementation "org.threeten:threetenbp:1.4.4"
 
     okhttpImplementation "io.swagger:swagger-annotations:1.5.24"

--- a/lib/src/main/java/au/com/woolworths/village/sdk/openapi/model/OpenApiAllowedPaymentMethods.kt
+++ b/lib/src/main/java/au/com/woolworths/village/sdk/openapi/model/OpenApiAllowedPaymentMethods.kt
@@ -2,18 +2,21 @@ package au.com.woolworths.village.sdk.openapi.model
 
 import au.com.woolworths.village.sdk.openapi.dto.MerchantProfileResponseAllowedPaymentMethods
 
-
 class OpenApiAllowedPaymentMethods(
     private val allowedPaymentMethods: MerchantProfileResponseAllowedPaymentMethods
 ) : au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethods {
-    override val giftCard: au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsGiftCard
-        get() = OpenApiAllowedPaymentMethodsGiftCard(allowedPaymentMethods.giftCard)
-    override val creditCard: au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsCreditCard
-        get() = OpenApiAllowedPaymentMethodsCreditCard(allowedPaymentMethods.creditCard)
-    override val paypal: au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsPaypal
-        get() = OpenApiAllowedPaymentMethodsPaypal(allowedPaymentMethods.payPal)
-    override val googlePay: au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsGooglePay
-        get() = OpenApiAllowedPaymentMethodsGooglePay(allowedPaymentMethods.googlePay)
-    override val applePay: au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsApplePay
-        get() = OpenApiAllowedPaymentMethodsApplePay(allowedPaymentMethods.applePay)
+    override val giftCard: au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsGiftCard?
+        get() = allowedPaymentMethods.giftCard?.let { OpenApiAllowedPaymentMethodsGiftCard(it) }
+
+    override val creditCard: au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsCreditCard?
+        get() = allowedPaymentMethods.creditCard?.let { OpenApiAllowedPaymentMethodsCreditCard(it) }
+
+    override val paypal: au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsPaypal?
+        get() = allowedPaymentMethods.payPal?.let { OpenApiAllowedPaymentMethodsPaypal(it) }
+
+    override val googlePay: au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsGooglePay?
+        get() = allowedPaymentMethods.googlePay?.let { OpenApiAllowedPaymentMethodsGooglePay(it) }
+
+    override val applePay: au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsApplePay?
+        get() = allowedPaymentMethods.applePay?.let { OpenApiAllowedPaymentMethodsApplePay(it) }
 }

--- a/lib/src/main/java/au/com/woolworths/village/sdk/openapi/model/OpenApiAllowedPaymentMethodsApplePay.kt
+++ b/lib/src/main/java/au/com/woolworths/village/sdk/openapi/model/OpenApiAllowedPaymentMethodsApplePay.kt
@@ -2,14 +2,17 @@ package au.com.woolworths.village.sdk.openapi.model
 
 import au.com.woolworths.village.sdk.openapi.dto.MerchantProfileResponseAllowedPaymentMethodsApplePay
 
-
 class OpenApiAllowedPaymentMethodsApplePay(
     private val applePay: MerchantProfileResponseAllowedPaymentMethodsApplePay
 ) : au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsApplePay {
     override val creditCard: au.com.woolworths.village.sdk.model.walletmanagement.Card
         get() = OpenApiGooglePayCreditCard(applePay.creditCard)
+
     override val debitCard: au.com.woolworths.village.sdk.model.walletmanagement.Card
         get() = OpenApiGooglePayDebitCard(applePay.debitCard)
+
     override val serviceStatus: au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus
-        get() = au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus.valueOf(applePay.serviceStatus.value)
+        get() = au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus.valueOf(
+            applePay.serviceStatus.value
+        )
 }

--- a/lib/src/main/java/au/com/woolworths/village/sdk/openapi/model/OpenApiAllowedPaymentMethodsCreditCard.kt
+++ b/lib/src/main/java/au/com/woolworths/village/sdk/openapi/model/OpenApiAllowedPaymentMethodsCreditCard.kt
@@ -2,20 +2,23 @@ package au.com.woolworths.village.sdk.openapi.model
 
 import au.com.woolworths.village.sdk.openapi.dto.MerchantProfileResponseAllowedPaymentMethodsCreditCard
 
-
 class OpenApiAllowedPaymentMethodsCreditCard(
-    private val creditCard: MerchantProfileResponseAllowedPaymentMethodsCreditCard?
+    private val creditCard: MerchantProfileResponseAllowedPaymentMethodsCreditCard
 ) : au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsCreditCard {
     override val allowedNetworks: List<String>
-        get() = creditCard!!.allowedNetworks
+        get() = creditCard.allowedNetworks
+
     override val serviceStatus: au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus
         get() = au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus.valueOf(
-            creditCard!!.serviceStatus.value
+            creditCard.serviceStatus.value
         )
-    override val allowedTransactionTypes: List<au.com.woolworths.village.sdk.model.walletmanagement.TransactionTypeEnum>
-        get() = creditCard!!.allowedTransactionTypes?.map(::toAllowedTransactionTypes) ?: emptyList()
 
-    fun toAllowedTransactionTypes(transactionType: MerchantProfileResponseAllowedPaymentMethodsCreditCard.AllowedTransactionTypesEnum): au.com.woolworths.village.sdk.model.walletmanagement.TransactionTypeEnum {
+    override val allowedTransactionTypes: List<au.com.woolworths.village.sdk.model.walletmanagement.TransactionTypeEnum>
+        get() = creditCard.allowedTransactionTypes?.map(::toAllowedTransactionTypes) ?: emptyList()
+
+    fun toAllowedTransactionTypes(
+        transactionType: MerchantProfileResponseAllowedPaymentMethodsCreditCard.AllowedTransactionTypesEnum
+    ): au.com.woolworths.village.sdk.model.walletmanagement.TransactionTypeEnum {
         return au.com.woolworths.village.sdk.model.walletmanagement.TransactionTypeEnum.valueOf(
             transactionType.value
         )

--- a/lib/src/main/java/au/com/woolworths/village/sdk/openapi/model/OpenApiAllowedPaymentMethodsGiftCard.kt
+++ b/lib/src/main/java/au/com/woolworths/village/sdk/openapi/model/OpenApiAllowedPaymentMethodsGiftCard.kt
@@ -2,14 +2,15 @@ package au.com.woolworths.village.sdk.openapi.model
 
 import au.com.woolworths.village.sdk.openapi.dto.MerchantProfileResponseAllowedPaymentMethodsGiftCard
 
-
 class OpenApiAllowedPaymentMethodsGiftCard(
-    private val giftCard: MerchantProfileResponseAllowedPaymentMethodsGiftCard?
+    private val giftCard: MerchantProfileResponseAllowedPaymentMethodsGiftCard
 ) : au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsGiftCard {
     override val allowedBins: List<String>
-        get() = giftCard!!.allowedBins
+        get() = giftCard.allowedBins
+
     override val serviceStatus: au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus
-        get() = au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus.valueOf(giftCard!!.serviceStatus.value)
+        get() = au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus.valueOf(giftCard.serviceStatus.value)
+
     override val pinAlwaysRequired: Boolean?
-        get() = giftCard!!.pinAlwaysRequired
+        get() = giftCard.pinAlwaysRequired
 }

--- a/lib/src/main/java/au/com/woolworths/village/sdk/openapi/model/OpenApiAllowedPaymentMethodsGooglePay.kt
+++ b/lib/src/main/java/au/com/woolworths/village/sdk/openapi/model/OpenApiAllowedPaymentMethodsGooglePay.kt
@@ -5,22 +5,31 @@ import java.math.BigDecimal
 
 
 class OpenApiAllowedPaymentMethodsGooglePay(
-    private val googlePay: MerchantProfileResponseAllowedPaymentMethodsGooglePay?
+    private val googlePay: MerchantProfileResponseAllowedPaymentMethodsGooglePay
 ) : au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsGooglePay {
     override val publicKey: String
-        get() = googlePay!!.publicKey
+        get() = googlePay.publicKey
+
     override val publicKeyHash: String
-        get() = googlePay!!.publicKeyHash
+        get() = googlePay.publicKeyHash
+
     override val merchantId: String
-        get() = googlePay!!.merchantId
+        get() = googlePay.merchantId
+
     override val publicKeyExpiry: BigDecimal
-        get() = googlePay!!.publicKeyExpiry
+        get() = googlePay.publicKeyExpiry
+
     override val merchantName: String
-        get() = googlePay!!.merchantName
+        get() = googlePay.merchantName
+
     override val creditCard: au.com.woolworths.village.sdk.model.walletmanagement.Card
-        get() = OpenApiGooglePayCreditCard(googlePay!!.creditCard)
+        get() = OpenApiGooglePayCreditCard(googlePay.creditCard)
+
     override val debitCard: au.com.woolworths.village.sdk.model.walletmanagement.Card
-        get() = OpenApiGooglePayDebitCard(googlePay!!.debitCard)
+        get() = OpenApiGooglePayDebitCard(googlePay.debitCard)
+
     override val serviceStatus: au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus
-        get() = au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus.valueOf(googlePay!!.serviceStatus.value)
+        get() = au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus.valueOf(
+            googlePay.serviceStatus.value
+        )
 }

--- a/lib/src/main/java/au/com/woolworths/village/sdk/openapi/model/OpenApiAllowedPaymentMethodsPaypal.kt
+++ b/lib/src/main/java/au/com/woolworths/village/sdk/openapi/model/OpenApiAllowedPaymentMethodsPaypal.kt
@@ -4,10 +4,13 @@ import au.com.woolworths.village.sdk.openapi.dto.MerchantProfileResponseAllowedP
 
 
 class OpenApiAllowedPaymentMethodsPaypal(
-    private val payPal: MerchantProfileResponseAllowedPaymentMethodsPayPal?
+    private val payPal: MerchantProfileResponseAllowedPaymentMethodsPayPal
 ) : au.com.woolworths.village.sdk.model.walletmanagement.AllowedPaymentMethodsPaypal {
     override val clientToken: String
-        get() = payPal!!.clientToken
+        get() = payPal.clientToken
+
     override val serviceStatus: au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus
-        get() = au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus.valueOf(payPal!!.serviceStatus.value)
+        get() = au.com.woolworths.village.sdk.model.walletmanagement.ServiceStatus.valueOf(
+            payPal.serviceStatus.value
+        )
 }


### PR DESCRIPTION
This fixes an issue where the allowed payment methods used Kotlin non-null assertions, which at runtime could have caused Null Pointer exceptions to be thrown on valid output from the API.