### PR TITLE
Chore/ci generate artefacts

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'maven' // Required for publishing to packagecloud
+apply plugin: 'maven-publish'
 
-group "au.com.woolworths.village.sdk.openapi"
+group "au.com.wpay.village.sdk"
 version "4.3.0"
 
 android {
@@ -48,6 +48,24 @@ configurations {
     deployerJars
 }
 
+task sourceJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier "sources"
+}
+
+project.afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.okhttpDebug
+                groupId = group
+                artifactId = 'openapi-sdk'
+                version = version
+            }
+        }
+    }
+}
+
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
@@ -74,14 +92,3 @@ dependencies {
     deployerJars "io.packagecloud.maven.wagon:maven-packagecloud-wagon:0.0.6"
 }
 
-uploadArchives {
-    repositories.mavenDeployer {
-        configuration = configurations.deployerJars
-        repository(url: "packagecloud+https://packagecloud.io/woolworths/paysdk2") {
-            authentication(password: System.getenv('PACKAGECLOUD_TOKEN'))
-        }
-        pom.groupId = project.group
-        pom.version = project.version
-        pom.artifactId = project.getName()
-    }
-}


### PR DESCRIPTION
**What's the chore?**

Adding the maven-publish plugin to generate aar artefacts as part of [Add CI](https://github.com/w-pay/sdk-wpay-openapi-android/issues/9)

**Why do we need to do it?**

Currently only jar files are being published: https://jitpack.io/com/github/w-pay/sdk-wpay-openapi-android/4.3.0/
We require aar files to be generated 