### PR TITLE
Adding maven-publish plugin to all submodules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ plugins {
 
 allprojects {
     repositories {
-        mavenLocal()
         google()
         jcenter()
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
 plugins {
     id 'project-report'
     id 'org.openapi.generator' version '4.3.1'
+    id 'maven-publish'
 }
 
 allprojects {
@@ -208,6 +209,7 @@ subprojects.each { sub ->
         }
     }
 }
+
 
 subprojects {
     apply plugin: 'maven-publish'

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ plugins {
 
 allprojects {
     repositories {
+        mavenLocal()
         google()
         jcenter()
         maven {
@@ -207,4 +208,11 @@ subprojects.each { sub ->
             }
         }
     }
+}
+
+subprojects {
+    apply plugin: 'maven-publish'
+
+    group "au.com.wpay.village.sdk"
+    version "4.4.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ buildscript {
 plugins {
     id 'project-report'
     id 'org.openapi.generator' version '4.3.1'
-    id 'maven-publish'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -208,11 +208,3 @@ subprojects.each { sub ->
         }
     }
 }
-
-
-subprojects {
-    apply plugin: 'maven-publish'
-
-    group "au.com.wpay.village.sdk"
-    version "4.4.0"
-}

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'maven-publish'
+
+group "au.com.wpay.village.sdk"
+version "4.4.0"
 
 android {
     compileSdkVersion 29

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,10 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'maven-publish'
-
-group "au.com.wpay.village.sdk"
-version "4.4.0"
 
 android {
     compileSdkVersion 29
@@ -57,7 +53,7 @@ project.afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
-                from components.okhttpDebug
+                from components.okhttpRelease
                 groupId = group
                 artifactId = 'openapi-sdk'
                 version = version

--- a/okhttp-gson/build.gradle
+++ b/okhttp-gson/build.gradle
@@ -2,6 +2,9 @@ apply plugin: 'idea'
 apply plugin: 'eclipse'
 apply plugin: 'java'
 
+group = 'au.com.woolworths.village.sdk.openapi'
+version = '0.0.6.0'
+
 buildscript {
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -77,20 +80,14 @@ if(hasProperty('target') && target == 'android') {
 } else {
 
     apply plugin: 'java'
+    apply plugin: 'maven'
 
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
 
-    project.afterEvaluate {
-        publishing {
-            publications {
-                release(MavenPublication) {
-                    from components.java
-                    groupId = group
-                    artifactId = 'okhttp-gson'
-                    version = version
-                }
-            }
+    install {
+        repositories.mavenInstaller {
+            pom.artifactId = 'okhttp-gson'
         }
     }
 

--- a/okhttp-gson/build.gradle
+++ b/okhttp-gson/build.gradle
@@ -80,14 +80,19 @@ if(hasProperty('target') && target == 'android') {
 } else {
 
     apply plugin: 'java'
-    apply plugin: 'maven-publish'
-    apply plugin: 'maven'
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
 
-    install {
-        repositories.mavenInstaller {
-            pom.artifactId = 'okhttp-gson'
+    project.afterEvaluate {
+        publishing {
+            publications {
+                release(MavenPublication) {
+                    from components.java
+                    groupId = group
+                    artifactId = 'okhttp-gson'
+                    version = version
+                }
+            }
         }
     }
 

--- a/okhttp-gson/build.gradle
+++ b/okhttp-gson/build.gradle
@@ -80,8 +80,8 @@ if(hasProperty('target') && target == 'android') {
 } else {
 
     apply plugin: 'java'
+    apply plugin: 'maven-publish'
     apply plugin: 'maven'
-
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
 

--- a/okhttp-gson/build.gradle
+++ b/okhttp-gson/build.gradle
@@ -83,19 +83,6 @@ if(hasProperty('target') && target == 'android') {
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
 
-    project.afterEvaluate {
-        publishing {
-            publications {
-                release(MavenPublication) {
-                    from components.java
-                    groupId = group
-                    artifactId = 'okhttp-gson'
-                    version = version
-                }
-            }
-        }
-    }
-
     task execute(type:JavaExec) {
        main = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath

--- a/okhttp-gson/build.gradle
+++ b/okhttp-gson/build.gradle
@@ -26,7 +26,7 @@ sourceSets {
 if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'com.android.library'
-    apply plugin: 'maven-publish'
+    apply plugin: 'com.github.dcendents.android-maven'
 
     android {
         compileSdkVersion 25

--- a/okhttp-gson/build.gradle
+++ b/okhttp-gson/build.gradle
@@ -2,9 +2,6 @@ apply plugin: 'idea'
 apply plugin: 'eclipse'
 apply plugin: 'java'
 
-group = 'au.com.woolworths.village.sdk.openapi'
-version = '0.0.6.0'
-
 buildscript {
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -80,14 +77,20 @@ if(hasProperty('target') && target == 'android') {
 } else {
 
     apply plugin: 'java'
-    apply plugin: 'maven'
 
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
 
-    install {
-        repositories.mavenInstaller {
-            pom.artifactId = 'okhttp-gson'
+    project.afterEvaluate {
+        publishing {
+            publications {
+                release(MavenPublication) {
+                    from components.java
+                    groupId = group
+                    artifactId = 'okhttp-gson'
+                    version = version
+                }
+            }
         }
     }
 

--- a/okhttp-gson/build.gradle
+++ b/okhttp-gson/build.gradle
@@ -26,7 +26,7 @@ sourceSets {
 if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'com.android.library'
-    apply plugin: 'com.github.dcendents.android-maven'
+    apply plugin: 'maven-publish'
 
     android {
         compileSdkVersion 25


### PR DESCRIPTION
**What's the chore?**

Adding the maven-publish plugin to generate aar artefacts

**Why do we need to do it?**

Currently only jar files are being published : https://jitpack.io/com/github/w-pay/sdk-wpay-openapi-android/v4.4.0/build.log

From the logs we can see that Jitpack is not running `publishToMavenLocal` which is what we require to have our aar artefacts generated correctly.
According to Jitpack [documentation](https://jitpack.io/docs/BUILDING/) the maven-publish plugin will run`./gradlew build publishToMavenLocal` which is what we're after. 

Currently it is running  `./gradlew  install` which is what Jitpack will run if the `'maven' `plugin is present. 

This PR applies the `maven-publish` plugin instead of the '`maven'` plugin to all submodules with a common group name and version number. 
After this PR there will be two artefacts generated under au.com.wpay.village.sdk:okhttp-gson:version-number and au.com.wpay.village.sdk:openapi-sdk:version-number. 

